### PR TITLE
Optimize hovercard generation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,3 +40,5 @@ gem "wdm", "~> 0.1.0" if Gem.win_platform?
 gem "webrick", "~> 1.8"
 
 gem "rexml", "~> 3.2"
+
+gem 'nokogiri'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,10 +49,15 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
+    nokogiri (1.16.3-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.3-x86_64-darwin)
+      racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     posix-spawn (0.3.15)
     public_suffix (5.0.1)
+    racc (1.7.3)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -77,6 +82,7 @@ DEPENDENCIES
   jekyll-last-modified-at
   jekyll-remote-theme
   jekyll-seo-tag
+  nokogiri
   rexml (~> 3.2)
   tzinfo-data
   webrick (~> 1.8)

--- a/_plugins/hoverCards.rb
+++ b/_plugins/hoverCards.rb
@@ -19,7 +19,22 @@ module Jekyll
     end
 
     def preserveParagraphs(post)
-        post.output = post.output.gsub(/<p>(.*?)<\/p>/m, '<div class="paragraph"><p>\1</p></div>')
+        doc = Nokogiri::HTML::DocumentFragment.parse(post.output)
+
+        # Select all p elements and all p elements that have a div.paragraph ancestor
+        all_p_elements = doc.css('p')
+        p_elements_in_paragraph = doc.css('div.paragraph p')
+
+        # Get all p elements that don't have a div.paragraph ancestor
+        p_elements_not_in_paragraph = all_p_elements - p_elements_in_paragraph
+
+        p_elements_not_in_paragraph.each do |p|
+            # Wrap the p element in a div.paragraph element
+            p.replace("<div class='paragraph'>#{p.to_html}</div>")
+        end
+
+        # Convert the modified document back into a string
+        post.output = doc.to_html
     end
 
     def insertHoverCards(post, site)

--- a/_posts/2024-03-22-coordinate-metaphors-3.md
+++ b/_posts/2024-03-22-coordinate-metaphors-3.md
@@ -11,3 +11,4 @@ tags: notes imagery cohesiveness writing
 From Ed Caesar's [tribute to Cormac McCarthy](https://www.newyorker.com/culture/postscript/cormac-mccarthys-narrative-wisdom), following the author's death in June 2023.
 
 Notice the coordination of **flames**, **fire**, and **extinguished**.
+Also notice that each of the images must work by itself so that their coordination does not devolve into a cheesy theme.


### PR DESCRIPTION
- [x] fix issue where local builds take a long time presumably because hovercards are being recursively built
- [x] fix issue where local dev reloads add multiple levels of `div.paragraph` wrappers, which cause newlines to be insert before and after hovercard hyperlinks
- [x] prevent hovercards from appearing within hovercards; right now, whether a hovercard opens within a hovercard depends on which order the hovercards are inserted during the build process
- [x] design for case where user hovers over hoverlink inside an existing hovercard