### PR TITLE
Make spacing offset of hovercards and its implementation consistent

### DIFF
--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -438,7 +438,8 @@ em, i {
   background-color: $background-color;
   border: 1px solid $border-color-01;
   border-radius: 10px;
-  margin: 0.75em;
+  left: 5px; // hovercardBufferPx in post.js
+  top: 5px; // hovercardBufferPx in post.js
   padding: 1em;
   overflow: hidden;
   overflow-y: auto;

--- a/assets/js/post.js
+++ b/assets/js/post.js
@@ -23,24 +23,19 @@ var observer = new IntersectionObserver(function(entries) {
         var linkQuadrant = linkCenterX < viewportCenterX
           ? linkCenterY < viewportCenterY ? 'top left' : 'bottom left'
           : linkCenterY < viewportCenterY ? 'top right' : 'bottom right';
-        if (linkQuadrant === 'top left') {
+
+        if (linkQuadrant.startsWith('top')) {
           hoverCard.style.top = hovercardBufferPx + 'px';
-          hoverCard.style.left = hovercardBufferPx + 'px';
-          hoverCard.style.right = 'auto';
-        } else if (linkQuadrant === 'bottom left') {
+        } else {
           hoverCard.style.top = 'auto';
           // "container" of hovercard has 0 area and its position does not line up with either the top or bottom of the hover link
           hoverCard.style.bottom = (hoverCardContainerRect.top - linkRect.top) + hovercardBufferPx + 'px';
+        }
+
+        if (linkQuadrant.endsWith('left')) {
           hoverCard.style.left = hovercardBufferPx + 'px';
           hoverCard.style.right = 'auto';
-        } else if (linkQuadrant === 'bottom right') {
-          hoverCard.style.top = 'auto';
-          // "container" of hovercard has 0 area and its position does not line up with either the top or bottom of the hover link
-          hoverCard.style.bottom = (hoverCardContainerRect.top - linkRect.top) + hovercardBufferPx + 'px';
-          hoverCard.style.left = 'auto';
-          hoverCard.style.right = linkRect.width + hovercardBufferPx + 'px';
-        } else if (linkQuadrant === 'top right') {
-          hoverCard.style.top = hovercardBufferPx + 'px';
+        } else {
           hoverCard.style.left = 'auto';
           hoverCard.style.right = linkRect.width + hovercardBufferPx + 'px';
         }

--- a/assets/js/post.js
+++ b/assets/js/post.js
@@ -6,8 +6,8 @@ var observer = new IntersectionObserver(function(entries) {
     const hoverCard = entry.target;
     if (hoverCard.style.display != 'none') {
       window.requestAnimationFrame(function() {
-        var rect = hoverCard.getBoundingClientRect();
-        var fullyInView = rect.top >= 0 && rect.left >= 0 && rect.bottom <= window.innerHeight && rect.right <= window.innerWidth;
+        var hoverCardRect = hoverCard.getBoundingClientRect();
+        var fullyInView = hoverCardRect.top >= 0 && hoverCardRect.left >= 0 && hoverCardRect.bottom <= window.innerHeight && hoverCardRect.right <= window.innerWidth;
         if (fullyInView) {
             return;
         }
@@ -26,10 +26,10 @@ var observer = new IntersectionObserver(function(entries) {
           hoverCard.style.top = '0px';
           hoverCard.style.right = '0px;'
         } else if (linkQuadrant === 'bottom left') {
-          hoverCard.style.top = '-' + (rect.height + linkRect.height) + 'px';
+          hoverCard.style.top = '-' + (hoverCardRect.height + linkRect.height) + 'px';
           hoverCard.style.right = '0px;'
         } else if (linkQuadrant === 'bottom right') {
-          hoverCard.style.top = '-' + (rect.height + linkRect.height) + 'px';
+          hoverCard.style.top = '-' + (hoverCardRect.height + linkRect.height) + 'px';
           hoverCard.style.right = linkRect.width + 'px';
         } else if (linkQuadrant === 'top right') {
           hoverCard.style.top = '0px';

--- a/assets/js/post.js
+++ b/assets/js/post.js
@@ -1,3 +1,4 @@
+const hovercardBufferPx = 5;
 var observer = new IntersectionObserver(function(entries) {
   entries.forEach(function(entry) {
     if (!entry.target.classList.contains('hover-card')) {
@@ -12,6 +13,7 @@ var observer = new IntersectionObserver(function(entries) {
             return;
         }
         const container = hoverCard.closest('.hover-card-container');
+        const hoverCardContainerRect = container.getBoundingClientRect();
         var correspondingHoverLink = container.parentElement.querySelector('.hover-link');
         var linkRect = correspondingHoverLink.getBoundingClientRect();
         var linkCenterX = linkRect.left + linkRect.width / 2;
@@ -22,18 +24,25 @@ var observer = new IntersectionObserver(function(entries) {
           ? linkCenterY < viewportCenterY ? 'top left' : 'bottom left'
           : linkCenterY < viewportCenterY ? 'top right' : 'bottom right';
         if (linkQuadrant === 'top left') {
-          // revert to default
-          hoverCard.style.top = '0px';
-          hoverCard.style.right = '0px;'
+          hoverCard.style.top = hovercardBufferPx + 'px';
+          hoverCard.style.left = hovercardBufferPx + 'px';
+          hoverCard.style.right = 'auto';
         } else if (linkQuadrant === 'bottom left') {
-          hoverCard.style.top = '-' + (hoverCardRect.height + linkRect.height) + 'px';
-          hoverCard.style.right = '0px;'
+          hoverCard.style.top = 'auto';
+          // "container" of hovercard has 0 area and its position does not line up with either the top or bottom of the hover link
+          hoverCard.style.bottom = (hoverCardContainerRect.top - linkRect.top) + hovercardBufferPx + 'px';
+          hoverCard.style.left = hovercardBufferPx + 'px';
+          hoverCard.style.right = 'auto';
         } else if (linkQuadrant === 'bottom right') {
-          hoverCard.style.top = '-' + (hoverCardRect.height + linkRect.height) + 'px';
-          hoverCard.style.right = linkRect.width + 'px';
+          hoverCard.style.top = 'auto';
+          // "container" of hovercard has 0 area and its position does not line up with either the top or bottom of the hover link
+          hoverCard.style.bottom = (hoverCardContainerRect.top - linkRect.top) + hovercardBufferPx + 'px';
+          hoverCard.style.left = 'auto';
+          hoverCard.style.right = linkRect.width + hovercardBufferPx + 'px';
         } else if (linkQuadrant === 'top right') {
-          hoverCard.style.top = '0px';
-          hoverCard.style.right = linkRect.width + 'px';
+          hoverCard.style.top = hovercardBufferPx + 'px';
+          hoverCard.style.left = 'auto';
+          hoverCard.style.right = linkRect.width + hovercardBufferPx + 'px';
         }
       });
     }


### PR DESCRIPTION
Give the same vertical and horizontal distance from link for all four possible hovercard positions.

Two sets of Before v.s. After screenshots below, showing the different for two of the 4 possible hovercard positions.

### Before

![image](https://github.com/okjuan/vbook/assets/13096220/bec8b5e3-bea7-40a5-8184-06c3cdfcace9)

### After

![image](https://github.com/okjuan/vbook/assets/13096220/afd61793-4fdb-4d0a-a86b-7aa9f8ee4564)

### Before

![image](https://github.com/okjuan/vbook/assets/13096220/90ae1fe3-0f00-4a84-b3b2-66642f40d8c0)

### After

![image](https://github.com/okjuan/vbook/assets/13096220/05b0d201-7731-4606-8c17-e297ee62f08e)
