### PR TITLE
Use names instead of ids to uniquely identify posts when creating hovercards

### DIFF
--- a/_plugins/hoverCards.rb
+++ b/_plugins/hoverCards.rb
@@ -39,9 +39,9 @@ module Jekyll
 
     def insertHoverCards(post, site)
         post.output = post.output.gsub(/<a id="(.*?)" class="internal-site-link"(.*?)<\/a>/) do
-          id = $1
+          post_name = $1
           restOfLink = $2
-          linked_post = site.posts.docs.find { |post| post.id == id }
+          linked_post = site.posts.docs.find { |post| File.basename(post.basename, ".md") == post_name }
           title = linked_post.data['title']
 
           doc = Nokogiri::HTML::DocumentFragment.parse(linked_post.output)

--- a/_plugins/internalSiteLinks.rb
+++ b/_plugins/internalSiteLinks.rb
@@ -12,7 +12,7 @@ module Jekyll
       site = context.registers[:site]
       post = site.posts.docs.find { |p| File.basename(p.basename, ".md") == @post_name }
       if post
-        "<a id='#{post.id}' class='internal-site-link' href='#{site.baseurl}#{post.permalink}'>#{@text}</a>"
+        "<a id='#{@post_name}' class='internal-site-link' href='#{site.baseurl}#{post.permalink}'>#{@text}</a>"
       else
         puts "ERROR:\n\tPost not found: @post_name=#{@post_name}\nERROR\n"
       end


### PR DESCRIPTION
Resolves #9