### PR TITLE
Allow users to order posts by modified date

### DIFF
--- a/_includes/posts_list.html
+++ b/_includes/posts_list.html
@@ -22,9 +22,7 @@
               {% assign modDateInSecs = post.modified_date | date: "%s" | minus: 0 %}
               {%- if modDateInSecs > postDateInSecs -%}
                 {%- assign mdate = post.modified_date | date_to_xmlschema -%}
-                <time class="dt-modified" datetime="{{ mdate }}" itemprop="dateModified">
-                  &nbsp;(mod. {{ mdate | date: date_format }})
-                </time>
+                &nbsp;(mod.&nbsp;<time class="dt-modified" datetime="{{ mdate }}" itemprop="dateModified">{{ mdate | date: date_format }}</time>)
               {%- endif -%}
             {%- endif -%}
           </span>

--- a/_includes/posts_list.html
+++ b/_includes/posts_list.html
@@ -1,5 +1,6 @@
 <div>
   <form id="post-order-controls">
+    Order by&nbsp;&nbsp;
     <div class="radio-button-group">
       <input type="radio" id="post-date" name="option" value="datePublished" checked>
       <label for="post-date">Post Date</label>

--- a/_includes/posts_list.html
+++ b/_includes/posts_list.html
@@ -1,4 +1,14 @@
-<ul class="post-list">
+<div>
+  <form id="post-order-controls">
+    <div class="radio-button-group">
+      <input type="radio" id="post-date" name="option" value="datePublished" checked>
+      <label for="post-date">Post Date</label>
+      <input type="radio" id="modified-date" name="option" value="dateModified">
+      <label for="modified-date">Modified Date</label>
+    </div>
+  </form>
+
+<ul class="post-list" id="post-list">
     {%- assign date_format = site.minima.date_format | default: "%b %-d %Y" -%}
     {%- for post in include.posts -%}
       {%- if page.category == nil or post.path contains page.category -%}
@@ -40,3 +50,4 @@
       {%- endif -%}
     {%- endfor -%}
 </ul>
+</div>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -44,6 +44,8 @@
       <script src="{{ site.baseurl }}/assets/js/post.js"></script>
     {% endif %}
 
+    <script src="{{ site.baseurl }}/assets/js/order_posts_list.js"></script>
+
   </body>
 
 </html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -22,9 +22,7 @@ layout: base
         {% assign modDateInSecs = page.modified_date | date: "%s" | minus: 0 %}
         {%- if modDateInSecs > postDateInSecs -%}
           {%- assign mdate = page.modified_date | date_to_xmlschema -%}
-          <time class="dt-modified" datetime="{{ mdate }}" itemprop="dateModified">
-            &nbsp;(mod. {{ mdate | date: date_format }})
-          </time>
+          &nbsp;(mod.&nbsp;<time class="dt-modified" datetime="{{ mdate }}" itemprop="dateModified">{{ mdate | date: date_format }}</time>)
         {%- endif -%}
       {%- endif -%}
       {%- if page.author -%}

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -476,3 +476,45 @@ em, i {
     width: calc(50% - (#{$spacing-unit} / 2));
   }
 }
+
+#post-order-controls {
+  float: right;
+}
+
+#post-order-controls {
+  display: flex;
+  align-items: center;
+}
+
+.radio-button-group {
+  display: flex;
+  border-radius: 10px;
+  border: 2px solid $border-color-03;
+}
+
+.radio-button-group input[type="radio"] {
+  display: none;
+}
+
+.radio-button-group label {
+  padding: 1px 7px;
+  border-style: solid;
+  border-color: transparent;
+  background-color: $background-color;
+  cursor: pointer;
+  font-size: $small-font-size;
+
+  &:first-of-type {
+    border-radius: 7px 0 0 7px; /* Top-left and bottom-left corners */
+    border-width: 3px 5px 3px 3px;
+  }
+
+  &:last-of-type {
+    border-radius: 0 7px 7px 0; /* Top-right and bottom-right corners */
+    border-width: 3px 3px 3px 5px;
+  }
+}
+
+.radio-button-group input[type="radio"]:checked + label {
+  border-color: $border-color-03;
+}

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -478,7 +478,15 @@ em, i {
 }
 
 #post-order-controls {
-  float: right;
+  display: block;
+  margin-bottom: $spacing-unit * 0.5;
+
+  @media screen and (min-width: $on-medium) {
+    float: right;
+    position: relative;
+    top: -($spacing-unit * 0.7);
+    margin: 0px;
+  }
 }
 
 #post-order-controls {

--- a/assets/js/order_posts_list.js
+++ b/assets/js/order_posts_list.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const form = document.getElementById('post-order-controls');
+    form.addEventListener('change', function() {
+        const selectedOption = document.querySelector('input[name="option"]:checked').value;
+        sortPosts(selectedOption);
+    });
+
+    function getDateFromElement(element, dateType) {
+        let dateElement = element.querySelector(`time[itemprop="${dateType}"]`);
+        if (dateElement === null) {
+            if (dateType === "dateModified") {
+                // fallback to published date when modified date is not defined
+                dateElement = element.querySelector(`time[itemprop="datePublished"]`);
+            } else if (dateType === "datePublished") {
+                throw new Error(`'datePublished' prop not found for element ${element}. It should always be defined`);
+            } else {
+                throw new Error(`Unexpected dateType: '${dateType}'`);
+            }
+        }
+        return new Date(dateElement.getAttribute('datetime'));
+    }
+
+    function sortPosts(sortKey) {
+        const postList = document.getElementById('post-list');
+        const posts = Array.from(postList.querySelectorAll('li'));
+        posts.sort((a, b) => {
+            const dateA = getDateFromElement(a, sortKey);
+            const dateB = getDateFromElement(b, sortKey);
+            return dateB - dateA;
+        });
+
+        // Clear the post list and append sorted posts
+        postList.innerHTML = '';
+        posts.forEach(post => postList.appendChild(post));
+    }
+});


### PR DESCRIPTION
Allow users to order posts by modified date via new two-button radio controls.

### Desktop

![Screenshot 2024-09-17 at 12 19 35 PM](https://github.com/user-attachments/assets/f37fbf11-395f-4264-8475-78c952eca94e)

### Mobile
![Screenshot 2024-09-17 at 12 20 02 PM](https://github.com/user-attachments/assets/7e95b137-fe78-4d79-9656-3047243a91af)
