### PR TITLE
Update modified_date of posts automatically using a pre-commit git hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 To run this site locally, you will need to have ruby and other things installed.
 Follow the instructions GitHub gives for developing GitHub Pages.
 
+After cloning this repo, run `git config core.hooksPath git_hooks/` to set up this repo's git hooks.
+You only need to do this once.
+
 # Development
 
 Run `bundle exec jekyll serve` to deploy this site locally.

--- a/git_hooks/pre-commit
+++ b/git_hooks/pre-commit
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+current_date=$(date +%Y-%m-%d)
+for file in $(git diff --cached --name-only | grep '^_posts/.*\.md$'); do
+  # If not already present, insert 'modified_date: ' to 2nd line of post
+  if ! grep -q 'modified_date:' "$file"; then
+    echo "Adding 'modified_date: ' to file $file"
+    # NOTE: newlines are necessary to make this work on Mac!
+    sed -i '' '2 i\
+modified_date:
+' "$file"
+  fi
+
+  # Update the 'modified_date' to the current date
+  sed -i '' "s/modified_date:.*/modified_date: $current_date/" "$file"
+
+  # Stage the file for commit
+  git add "$file"
+done
+
+# Exit successfully
+exit 0


### PR DESCRIPTION
Add a pre-commit git hook that sets modified_date for `_posts/*md` files.

This is the last step in implementing modified dates! Also see `post_modified_date` and `post_modified_date_v2`.