### PR TITLE
Implement revisions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,3 +42,5 @@ gem "rexml", "~> 3.2"
 gem 'nokogiri'
 
 gem "kramdown-parser-gfm"
+
+gem "git"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,25 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (7.2.1)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
     colorator (1.1.0)
     concurrent-ruby (1.3.3)
+    connection_pool (2.4.1)
+    drb (2.2.1)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -12,6 +27,11 @@ GEM
     ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86_64-darwin)
     forwardable-extended (2.6.0)
+    git (2.3.0)
+      activesupport (>= 5.0)
+      addressable (~> 2.8)
+      process_executer (~> 1.1)
+      rchardet (~> 1.8)
     http_parser.rb (0.8.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
@@ -49,18 +69,22 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.6.1)
     mercenary (0.3.6)
+    minitest (5.25.1)
     nokogiri (1.16.3-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.3-x86_64-darwin)
       racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    process_executer (1.1.0)
     public_suffix (5.1.1)
     racc (1.7.3)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
+    rchardet (1.8.0)
     rexml (3.3.0)
       strscan
     rouge (3.30.0)
@@ -71,7 +95,10 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    securerandom (0.3.1)
     strscan (3.1.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     webrick (1.8.1)
 
 PLATFORMS
@@ -79,6 +106,7 @@ PLATFORMS
   x86_64-darwin-22
 
 DEPENDENCIES
+  git
   jekyll (~> 3.9.5)
   jekyll-feed (~> 0.17)
   jekyll-remote-theme

--- a/_config.yml
+++ b/_config.yml
@@ -37,6 +37,11 @@ defaults:
     values:
       layout: tag_page
       permalink: tags/:tag/
+  - scope:
+      type: revs  # select all revisions pages
+    values:
+      layout: post
+      permalink: revs/:rev/
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -25,6 +25,39 @@ layout: base
           &nbsp;(mod.&nbsp;<time class="dt-modified" datetime="{{ mdate }}" itemprop="dateModified">{{ mdate | date: date_format }}</time>)
         {%- endif -%}
       {%- endif -%}
+      {%- if page.show_revisions -%}
+        {% if page.revision_number == 0 %}
+          {% assign revision_count = page.revision_count %}
+          {% assign latest_version = page %}
+        {% else %}
+          {% assign revision_count = page.current_post.revision_count %}
+          {% assign latest_version = page.current_post %}
+        {% endif %}
+
+        {%- if revision_count > 0 -%}
+          {% assign n = revision_count | plus: page.revision_number %}
+          {% assign cur_revision = page %}
+          {% for r in (1..n) %}
+            {% assign cur_revision = cur_revision.prev_rev %}
+          {% endfor %}
+
+          <span id="revisions-nav">
+            {{revision_count}} revisions:&nbsp;
+            {%- for r in (1..revision_count) -%}
+              {%- assign sep = ', ' -%}
+              {%- if cur_revision.revision_number == revision_count -%}
+                {%- assign sep = '' -%}
+              {%- endif -%}
+              {%- if cur_revision.revision_number == page.revision_number -%}
+                <a href="/vbook/revs{{latest_version.permalink}}/{{cur_revision.revision_number}}/"><b>{{r}}</b></a>{{sep}}
+              {% else %}
+                <a href="/vbook/revs{{latest_version.permalink}}/{{cur_revision.revision_number}}/">{{r}}</a>{{sep}}
+              {%- endif -%}
+              {%- assign cur_revision = cur_revision.next_rev -%}
+            {%- endfor -%}
+          </span>
+        {%- endif -%}
+      {%- endif -%}
       {%- if page.author -%}
         • {% for author in page.author %}
           <span itemprop="author" itemscope itemtype="http://schema.org/Person">

--- a/_plugins/backlinks.rb
+++ b/_plugins/backlinks.rb
@@ -3,7 +3,7 @@ module Jekyll
     def backlink(target_post)
       backlinks = []
       # e.g. _posts/2022-02-02-dune.md => 2022-02-02-dune
-      post_file_name = File.basename(target_post.path,File.extname(target_post.path))
+      post_file_name = File.basename(target_post['path'],File.extname(target_post['path']))
 
       # Ruby notes
       # ---
@@ -26,8 +26,8 @@ module Jekyll
         # ---
         # 1. '&' is the safe navigation operator, which is like the '?.' operator in JS
         # 2. '?' is a convention for methods that return a boolean; it doesn't actually do anything
-        if post&.content&.include?(post_file_name) || post&.content&.include?("#{site.baseurl}#{target_post.url}")
-          if post&.url != target_post.url
+        if post&.content&.include?(post_file_name) || post&.content&.include?("#{site.baseurl}#{target_post['url']}")
+          if post&.url != target_post['url']
             # Ruby notes
             # ---
             # 1. '<<' is an operator that can be overriden; for arrays, it overrides the push method

--- a/_plugins/revisions.rb
+++ b/_plugins/revisions.rb
@@ -1,0 +1,140 @@
+require 'git'
+
+module Revision
+  class RevisionPageGenerator < Jekyll::Generator
+    safe true
+
+    def generate(site)
+      repo = Git.open('.')
+      site.posts.docs.each do |post|
+        if post['show_revisions']
+          log = repo.log.path(post.path)
+          current_commit = log.first
+          revision_number = -1
+          revision_count = 0
+          current_post = post
+          log.each do |previous_commit|
+            next if previous_commit.sha == current_commit.sha
+            git_word_diff = get_word_diff(post.path, previous_commit.sha, current_commit.sha)
+
+            content_diff = strip_metadata(git_word_diff)
+            next unless any_diff(content_diff)
+
+            ## Replace diff tokens with Markdown formatting
+            formatted_diff = content_diff
+              .gsub('{+', ' **').gsub('+}', '** ')
+              .gsub('[-', ' ~~').gsub('-]', '~~ ')
+
+            markdown_converter = site.find_converter_instance(Jekyll::Converters::Markdown)
+            html_content = markdown_converter.convert(formatted_diff)
+
+            doc = Nokogiri::HTML::DocumentFragment.parse(html_content)
+            all_p_elements = doc.css('p')
+            all_p_elements.each do |p|
+                # Wrap the p element in a div.paragraph element
+                p.replace("<div class='paragraph'>#{p.to_html}</div>")
+            end
+
+            rev_date = current_commit.date.strftime('%Y-%m-%d')
+            rev = RevisionPage.new(site, post, doc.to_html, revision_number, rev_date)
+            site.pages << rev
+            current_post.data['prev_rev'] = rev
+            rev.data['next_rev'] = current_post
+            revision_number -= 1
+            revision_count += 1
+            current_commit = previous_commit
+            current_post = rev
+          end
+          post.data['revision_count'] = revision_count
+          post.data['revision_number'] = 0
+        end
+      end
+    end
+
+    def get_word_diff(file_path, commit1, commit2)
+      # -U1000 sets context to 999999 lines
+      command = "git diff --word-diff -U999999 #{commit1} #{commit2} -- #{file_path}"
+      stdout, stderr, status = Open3.capture3(command)
+      if status.success?
+        stdout
+      else
+        raise "Error running git diff: #{stderr}"
+      end
+    end
+
+    def strip_metadata(git_word_diff)
+      # Remove Git metadata
+      git_word_diff
+        .gsub(/^diff --git.*\n/, '')
+        .gsub(/^index .*\n/, '')
+        .gsub(/^--- .*\n/, '')
+        .gsub(/^\+\+\+ .*\n/, '')
+        .gsub(/^@@ .* @@\n/, '')
+        # Remove YAML frontmatter
+        .gsub(/^---\n.*?\n---\n\n?/m, '')
+        ## Remove HTML comments
+        .gsub(/\s*<!--.*?-->/, '')
+    end
+
+    def any_diff(git_word_diff)
+      git_word_diff.match?(/\{\+.*?\+\}/) || git_word_diff.match?(/\[-.*?-\]/)
+    end
+  end
+
+  class RevisionPage < Jekyll::Page
+    def initialize(site, current_post, content, revision_number, revision_date)
+      @site = site             # the current site instance.
+      @base = site.source      # path to the source directory.
+      @dir  = "#{current_post.permalink}/#{revision_number}" # the directory the page will reside in.
+      @current_post = current_post
+
+      @basename = "index"      # filename without the extension.
+      @ext      = '.html'      # the extension.
+      @name     = "index.html" # basically @basename + @ext.
+      @content  = content
+
+      @title = "#{current_post["title"]} revision n#{revision_number}"
+      @subtitle = current_post['subtitle']
+      @subsubtitle = current_post['subsubtitle']
+      @date = current_post['date']
+      @modified_date = revision_date
+      @show_revisions = current_post['show_revisions']
+      @author = current_post['author']
+      @tags = current_post['tags']
+      @note = current_post['note']
+
+      # This allows accessing in *html file via `page.revision_number`, for example.
+      @data = {
+          'revision_number' => revision_number,
+          'current_post_url' => current_post.permalink,
+          'rev' => revision_number,
+          'title' => current_post['title'],
+          'subtitle' => current_post['subtitle'],
+          'subsubtitle' => current_post['subsubtitle'],
+          'date' => current_post['date'],
+          'modified_date' => revision_date,
+          'show_revisions' => current_post['show_revisions'],
+          'author' => current_post['author'],
+          'tags' => current_post['tags'],
+          'note' => current_post['note'],
+          'current_post' => current_post
+      }
+
+      # Look up front matter defaults scoped to type `tags`, if given key
+      # doesn't exist in the `data` hash.
+      data.default_proc = proc do |_, key|
+        site.frontmatter_defaults.find(relative_path, :revs, key)
+      end
+    end
+
+    # Placeholders that are used in constructing page URL.
+    def url_placeholders
+      {
+        :path       => @dir,
+        :rev   => @dir,
+        :basename   => basename,
+        :output_ext => output_ext,
+      }
+    end
+  end
+end

--- a/_posts/2024-08-30-good-shower.md
+++ b/_posts/2024-08-30-good-shower.md
@@ -4,6 +4,7 @@ layout: post
 title: what makes a good shower?
 permalink: /good-shower
 tags: notes design
+show_revisions: true
 ---
 
 The standard bathtub-shower design seems like a good idea.

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -515,3 +515,12 @@ em, i {
 #post-order-controls-label {
   padding: 0px 7px;
 }
+
+#revisions-nav {
+  padding: 0px 10px;
+  color: $text-color;
+}
+
+#revisions-nav > a {
+  cursor: pointer;
+}


### PR DESCRIPTION
Resolves #15 

### Example

By setting `show_revisions: true` in the front matter of `_posts/good-shower.md`, a new page is generated for each revision of the post:
- `vbook/revs/good-shower/-1/`, which represents the most recent revision
- `vbook/revs/good-shower/-2/`, which represents the revision before the most recent one
- `vbook/revs/good-shower/-3/`, etc
- `vbook/revs/good-shower/-4/`, etc

This is what `vbook/revs/good-shower/-2/` looks like:

<img width="816" alt="Screenshot 2024-09-22 at 6 42 36 PM" src="https://github.com/user-attachments/assets/f045cd35-3556-4ea7-a6e7-25b2cb0a4627">

The current implementation is confusing because it uses two numbering systems. One that is in negative numbers because it is relative to the newest version of the post and the other in positive numbers that counts up from the first revision to the last. That's why is `3` bolded for revision `-2`. I should fix this.
