### PR TITLE
Add links between posts in a series

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -28,9 +28,7 @@ layout: base
 
       {%- if page.in_post_series -%}
         <span id="post-series-nav">
-          &nbsp;&#9670;&nbsp;&nbsp;
-          This is post #{{page.number_in_series}} of {{page.series_total}} in series <em>{{page.series_name}}</em>.
-          &nbsp;See
+          &nbsp;&#9670;&nbsp;&nbsp;See
           {% assign separator = ' ' %}
           {%- if page.prev_post_in_series -%}
             the <a href="{{site.baseurl}}{{page.prev_post_in_series.url}}">previous post</a>
@@ -39,7 +37,7 @@ layout: base
           {%- if page.next_post_in_series -%}
             {{separator}}the <a href="{{site.baseurl}}{{page.next_post_in_series.url}}">next post</a>
           {%- endif -%}
-          .
+          &nbsp;in this series.
         </span>
       {%- endif -%}
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -25,6 +25,26 @@ layout: base
           &nbsp;(mod.&nbsp;<time class="dt-modified" datetime="{{ mdate }}" itemprop="dateModified">{{ mdate | date: date_format }}</time>)
         {%- endif -%}
       {%- endif -%}
+
+      {%- if page.in_post_series -%}
+        <span id="post-series-nav">
+          &nbsp;&#9670;&nbsp;&nbsp;
+          This is a series!
+          <!-- This is post #{{page.number_in_series}} of {{page.series_total}} in series <em>{{page.series_name}}</em>.
+          &nbsp;See
+          {% assign separator = ' ' %}
+          {%- if page.prev_post_in_series -%}
+            the <a href="{{site.baseurl}}{{page.prev_post_in_series.url}}">previous post</a>
+            {%- assign separator = ' or ' -%}
+          {%- endif -%}
+          {%- if page.next_post_in_series -%}
+            {{separator}}the <a href="{{site.baseurl}}{{page.next_post_in_series.url}}">next post</a>
+          {%- endif -%}
+          . -->
+        </span>
+      {%- endif -%}
+
+
       {%- if page.show_revisions -%}
         {% if page.final_version %}
           {% assign revision_count = page.revision_count %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -29,8 +29,7 @@ layout: base
       {%- if page.in_post_series -%}
         <span id="post-series-nav">
           &nbsp;&#9670;&nbsp;&nbsp;
-          This is a series!
-          <!-- This is post #{{page.number_in_series}} of {{page.series_total}} in series <em>{{page.series_name}}</em>.
+          This is post #{{page.number_in_series}} of {{page.series_total}} in series <em>{{page.series_name}}</em>.
           &nbsp;See
           {% assign separator = ' ' %}
           {%- if page.prev_post_in_series -%}
@@ -40,7 +39,7 @@ layout: base
           {%- if page.next_post_in_series -%}
             {{separator}}the <a href="{{site.baseurl}}{{page.next_post_in_series.url}}">next post</a>
           {%- endif -%}
-          . -->
+          .
         </span>
       {%- endif -%}
 

--- a/_plugins/post_series_links.rb
+++ b/_plugins/post_series_links.rb
@@ -14,10 +14,6 @@ module PostSeriesLinks
         # e.g. 'how to tell a story' => 1
         post_number = match_data[2] ? match_data[2].to_i : 1
 
-        if series_title != post.data['title']
-          puts "#{post.data['title']} => #{series_title}"
-        end
-
         if post_series.key?(series_title)
           if post_series[series_title].key?(post_number)
             error_message = <<~ERROR

--- a/_plugins/post_series_links.rb
+++ b/_plugins/post_series_links.rb
@@ -1,0 +1,33 @@
+module PostSeriesLinks
+  class PostSeriesLinksGenerator < Jekyll::Generator
+    safe true
+
+    def generate(site)
+      post_series = {}
+      site.posts.docs.each do |post|
+        # e.g. 'how to tell a story #3' => 'how to tell a story'
+        series_title = post.data['title'].sub(/\s*#\d+\s*$/, '')
+        # if series_title != post.data['title']
+          # puts "#{post.data['title']} => #{series_title}"
+        # end
+        if post_series.key?(series_title)
+          puts "Putting post '#{post.data['title']}' in series '#{series_title}'"
+
+          # page.in_post_series
+          post_series[series_title][0].data['in_post_series'] = true
+          post.data['in_post_series'] = true
+
+          # post.number_in_series
+          # post.series_total
+          # post.series_name
+          # post.prev_post_in_series
+          # post.next_post_in_series
+
+          post_series[series_title] << post
+        else
+          post_series[series_title] = [post]
+        end
+      end
+    end
+  end
+end

--- a/_plugins/post_series_links.rb
+++ b/_plugins/post_series_links.rb
@@ -5,27 +5,44 @@ module PostSeriesLinks
     def generate(site)
       post_series = {}
       site.posts.docs.each do |post|
+        match_data = post.data['title'].match(/^(.*?)(?:\s*#(\d+))?\s*$/)
+
         # e.g. 'how to tell a story #3' => 'how to tell a story'
-        series_title = post.data['title'].sub(/\s*#\d+\s*$/, '')
-        # if series_title != post.data['title']
-          # puts "#{post.data['title']} => #{series_title}"
-        # end
+        series_title = match_data[1].strip
+
+        # e.g. 'how to tell a story #3' => 3
+        # e.g. 'how to tell a story' => 1
+        post_number = match_data[2] ? match_data[2].to_i : 1
+
+        if series_title != post.data['title']
+          puts "#{post.data['title']} => #{series_title}"
+        end
+
         if post_series.key?(series_title)
-          puts "Putting post '#{post.data['title']}' in series '#{series_title}'"
+          if post_series[series_title].key?(post_number)
+            error_message = <<~ERROR
+              There should only be one post per series #number but found two:
+              1) #{post.data['title']}
+              2) #{post_series[series_title][post_number].data['title']}
+            ERROR
+            raise error_message
+          end
 
-          # page.in_post_series
-          post_series[series_title][0].data['in_post_series'] = true
-          post.data['in_post_series'] = true
-
-          # post.number_in_series
-          # post.series_total
-          # post.series_name
-          # post.prev_post_in_series
-          # post.next_post_in_series
-
-          post_series[series_title] << post
+          post_series[series_title][post_number] = post
+          post.data['number_in_series'] = post_number
         else
-          post_series[series_title] = [post]
+          post_series[series_title] = {post_number => post}
+        end
+      end
+
+      post_series.each do |series_title, posts|
+        posts.each do |post_number, post|
+          post.data['in_post_series'] = true
+          post.data['number_in_series'] = post_number
+          post.data['series_total'] = posts.size
+          post.data['series_name'] = series_title
+          post.data['prev_post_in_series'] = posts[post_number - 1]
+          post.data['next_post_in_series'] = posts[post_number + 1]
         end
       end
     end

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -517,12 +517,12 @@ em, i {
   text-decoration: underline;
 }
 
-#revisions-nav {
+#post-series-nav, #revisions-nav {
   padding: 0px;
   color: $text-color;
 }
 
-#revisions-nav > a {
+#post-series-nav > a, #revisions-nav > a {
   cursor: pointer;
 }
 


### PR DESCRIPTION
Resolves #14 

Below are a few screenshots from local testing. Look at the message `See the previous post in this series.`

![Screenshot 2025-03-05 at 10 40 53 AM](https://github.com/user-attachments/assets/3576b793-4a99-403e-91e5-22cbdeb0773b)

![image](https://github.com/user-attachments/assets/108a4651-ca05-4162-9a23-7373d8aab9a0)

This is what it looks like when the post also has revisions:

![image](https://github.com/user-attachments/assets/cc823117-d924-42a6-8406-beada1034f52)

